### PR TITLE
为底部ICP备案号添加工信部跳转

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -30,7 +30,7 @@
         </div>
         <footer class="absolute bottom-0 left-0 right-0 w-full bg-gray-200">
             <p class="container mx-auto py-2 px-5 sm:px-10 md:px-10 lg:px-10 xl:px-10 2xl:px-60 flex items-center text-gray-500 text-sm">
-                Copyright © 2018 - present Lsky Pro. All rights reserved. {{ \App\Utils::config(\App\Enums\ConfigKey::IcpNo) }} 请勿上传违反中国大陆和香港法律的图片，违者后果自负。
+                Copyright © 2018 - present Lsky Pro. All rights reserved. &nbsp;<a href="https://beian.miit.gov.cn/">{{ \App\Utils::config(\App\Enums\ConfigKey::IcpNo) }}</a>&nbsp;请勿上传违反中国大陆和香港法律的图片，违者后果自负。
             </p>
         </footer>
     </div>


### PR DESCRIPTION
根据[《非经营性互联网信息服务备案管理办法》](http://www.gov.cn/gongbao/content/2005/content_93018.htm) 第十三条规定：“非经营性互联网信息服务提供者应当在其网站开通时在主页底部的中央位置标明其备案编号，并在备案编号下方按要求链接信息产业部备案管理系统网址，供公众查询核对。”
根据测试，目前设计中并未自动对ICP备案号部分添加相应跳转。虽然该PR实现效果并不优雅，但也没有毛病（