### PR TITLE
路径命名可为空

### DIFF
--- a/app/Models/Image.php
+++ b/app/Models/Image.php
@@ -174,7 +174,7 @@ class Image extends Model
             if ($this->group?->configs->get(GroupConfigKey::IsEnableOriginalProtection)) {
                 return asset("{$this->key}.{$this->extension}");
             } else {
-                return rtrim($this->strategy?->configs->get('url'), '/').'/'.$this->pathname;
+                return rtrim($this->strategy?->configs->get('url'), '/').'/'.ltrim($this->pathname, '/');
             }
         });
     }


### PR DESCRIPTION
设置中路径命名为空时，图片链接省去多余的“/”。