### PR TITLE
修复前端水印上传目录提示错误的问题

### DIFF
--- a/resources/views/admin/group/add.blade.php
+++ b/resources/views/admin/group/add.blade.php
@@ -277,7 +277,7 @@
                                     <div class="col-span-6 sm:col-span-3 mb-4">
                                         <label for="configs[watermark_configs][drivers][image][image]" class="block text-sm font-medium text-gray-700"><span class="text-red-600">*</span>水印图片</label>
                                         <x-input type="text" name="configs[watermark_configs][drivers][image][image]" id="configs[watermark_configs][drivers][image][image]" autocomplete="image" placeholder="请输入水印路径，例如：images/lsky.png" />
-                                        <small class="text-yellow-500">请将水印图片放置 {{ public_path() }} 目录下</small>
+                                        <small class="text-yellow-500">请将水印图片放置 {{ storage_path('app/public') }} 目录下</small>
                                     </div>
                                     <div class="col-span-6 sm:col-span-3 mb-4">
                                         <label for="configs[watermark_configs][drivers][image][position]" class="block text-sm font-medium text-gray-700"><span class="text-red-600">*</span>水印位置</label>


### PR DESCRIPTION
e.g. 本应放在 /storage/app/public 目录下(与文字水印的字体存储位置相同)
     但前端提示放在 /public 目录下

图片放在 /public 目录下会提示无效
![屏幕截图 2022-09-28 000908](https://user-images.githubusercontent.com/86408775/192580032-a1f6ed95-5e82-44b3-a228-3ac5655c7dfa.png)
![屏幕截图 2022-09-28 001526](https://user-images.githubusercontent.com/86408775/192580038-7e59a22f-dcb6-464a-b69f-6d9cefc20bca.png)
