### PR TITLE
fix(图片上传): 修复同时上传多张图，有几张小概率变成同一张图的问题

### DIFF
--- a/app/Services/ImageService.php
+++ b/app/Services/ImageService.php
@@ -160,7 +160,7 @@ class ImageService
                 // 获取拓展名，判断是否需要转换
                 $format = $format ?: $extension;
                 $filename = Str::replaceLast($extension, $format, $file->getClientOriginalName());
-                $handleImage = InterventionImage::make($file)->save($format, $quality);
+                $handleImage = InterventionImage::make($file)->save('tmp_' . md5_file($file->getRealPath()), $quality);
                 $file = new UploadedFile($handleImage->basePath(), $filename, $handleImage->mime());
                 // 重新设置拓展名
                 $extension = $format;
@@ -270,6 +270,9 @@ class ImageService
         if(!in_array($extension, ['svg'])) {
             $this->makeThumbnail($image, $file);
         }
+
+        // 上传完成后删除临时文件
+        unlink($file->getPathname());
 
         return $image;
     }


### PR DESCRIPTION
同时上传多张图，在“格式转换”时用$format命名临时文件，有可能会在后续上传到存储空间时取用同一个临时文件，从而导致最终获得的图片一样（小概率，比较难复现，但在使用TS版php亦复现过，而且一出现那就会冲掉某张图）。
