### PR TITLE
perf: 优化svg预览

### DIFF
--- a/app/Models/Image.php
+++ b/app/Models/Image.php
@@ -240,7 +240,7 @@ class Image extends Model
 
     public function getThumbnailPathname(): string
     {
-        return trim(config('app.thumbnail_path'), '/')."/{$this->md5}.png";
+        return trim(config('app.thumbnail_path'), '/')."/{$this->md5}.". ($this->extension === 'svg' ? 'svg' : "png");
     }
 
     private function generateKey($length = 6): string

--- a/app/Services/ImageService.php
+++ b/app/Services/ImageService.php
@@ -266,10 +266,7 @@ class ImageService
             }
         }
 
-        // 生成缩略图，svg等格式本身体积足够小且网页原生支持(比生成的png缩略图还小)，不用生成缩略图
-        if(!in_array($extension, ['svg'])) {
-            $this->makeThumbnail($image, $file);
-        }
+        $this->makeThumbnail($image, $file);
 
         return $image;
     }
@@ -557,21 +554,26 @@ class ImageService
                     @mkdir(dirname($pathname));
                 }
 
-                @ini_set('memory_limit', '512M');
+                // 生成缩略图，svg等格式本身体积足够小且网页原生支持(比生成的png缩略图还小)，不用生成缩略图，直接复制文件
+                if($image->extension ==='svg') {
+                    copy($data->getPathname(), $pathname);
+                }else{
+                    @ini_set('memory_limit', '512M');
 
-                $img = InterventionImage::make($data);
+                    $img = InterventionImage::make($data);
 
-                $width = $w = $image->width;
-                $height = $h = $image->height;
+                    $width = $w = $image->width;
+                    $height = $h = $image->height;
 
-                if ($w > $max && $h > $max) {
-                    $scale = min($max / $w, $max / $h);
-                    $width  = (int)($w * $scale);
-                    $height = (int)($h * $scale);
+                    if ($w > $max && $h > $max) {
+                        $scale = min($max / $w, $max / $h);
+                        $width  = (int)($w * $scale);
+                        $height = (int)($h * $scale);
+                    }
+
+                    $img->fit($width, $height, fn($constraint) => $constraint->upsize())->encode('png', 60)->save($pathname);
+                    $img->destroy();
                 }
-
-                $img->fit($width, $height, fn($constraint) => $constraint->upsize())->encode('png', 60)->save($pathname);
-                $img->destroy();
             } catch (\Throwable $e) {
                 Utils::e($e, '生成缩略图时出现异常');
             }


### PR DESCRIPTION
此前删掉了svg缩略图的创建，因为svg足够小加载足够快。

但实际用户有可能把图片文件存在其他地方（比如S3存储桶），从那里获取svg源文件有可能会比较慢，所以改成了直接拷贝一份svg源文件放缩略图目录中提高预览速度。

此条只是优化svg预览，但**修改了缩略图底层函数**，因此不一定要合入，毕竟预览慢一丢丢也不是什么大事。